### PR TITLE
Update core_signing.py

### DIFF
--- a/django_q/core_signing.py
+++ b/django_q/core_signing.py
@@ -6,7 +6,7 @@ from django.core.signing import BadSignature, JSONSerializer, SignatureExpired
 from django.core.signing import Signer as Sgnr
 from django.core.signing import TimestampSigner as TsS
 from django.core.signing import b64_decode, dumps
-from django.utils import baseconv
+from django.core.signing import b62_encode as encode
 from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_bytes, force_str
 
@@ -69,7 +69,7 @@ class TimestampSigner(Signer, TsS):
         """
         result = super(TimestampSigner, self).unsign(value)
         value, timestamp = result.rsplit(self.sep, 1)
-        timestamp = baseconv.base62.decode(timestamp)
+        timestamp = encode(timestamp)
         if max_age is not None:
             if isinstance(max_age, datetime.timedelta):
                 max_age = max_age.total_seconds()


### PR DESCRIPTION
Django 5.0 warnings: baseconv is deprecated.

cannot import name 'baseconv'